### PR TITLE
add support for scan op

### DIFF
--- a/jsonpath.go
+++ b/jsonpath.go
@@ -144,7 +144,7 @@ func (c *Compiled) Lookup(obj interface{}) (interface{}, error) {
 				return nil, err
 			}
 		default:
-			return nil, fmt.Errorf("expression don't support in filter")
+			return nil, fmt.Errorf("unsupported operation: %s", s.op)
 		}
 	}
 	return obj, nil
@@ -359,7 +359,7 @@ func filter_get_from_explicit_path(obj interface{}, path string) (interface{}, e
 				return nil, err
 			}
 		default:
-			return nil, fmt.Errorf("expression don't support in filter")
+			return nil, fmt.Errorf("unsupported operation %s in filter", op)
 		}
 	}
 	return xobj, nil

--- a/jsonpath.go
+++ b/jsonpath.go
@@ -568,8 +568,9 @@ func get_scan(obj interface{}) (interface{}, error) {
 			}
 			return res, nil
 		}
-		for _, kv := range reflect.ValueOf(obj).MapKeys() {
-			res = append(res, reflect.ValueOf(obj).MapIndex(kv).Interface())
+		iter := reflect.ValueOf(obj).MapRange()
+		for iter.Next() {
+			res = append(res, iter.Value().Interface())
 		}
 		return res, nil
 	case reflect.Slice:

--- a/jsonpath.go
+++ b/jsonpath.go
@@ -144,7 +144,7 @@ func (c *Compiled) Lookup(obj interface{}) (interface{}, error) {
 				return nil, err
 			}
 		default:
-			return nil, fmt.Errorf("unsupported operation: %s", s.op)
+			return nil, fmt.Errorf("unsupported jsonpath operation: %s", s.op)
 		}
 	}
 	return obj, nil
@@ -359,7 +359,7 @@ func filter_get_from_explicit_path(obj interface{}, path string) (interface{}, e
 				return nil, err
 			}
 		default:
-			return nil, fmt.Errorf("unsupported operation %s in filter", op)
+			return nil, fmt.Errorf("unsupported jsonpath operation %s in filter", op)
 		}
 	}
 	return xobj, nil

--- a/jsonpath_test.go
+++ b/jsonpath_test.go
@@ -337,7 +337,7 @@ func Test_jsonpath_parse_token(t *testing.T) {
 
 		if op == "range" {
 			if args_v, ok := args.([2]interface{}); ok == true {
-				fmt.Println(args_v)
+				t.Logf("%v", args_v)
 				exp_from := exp_args.([2]interface{})[0]
 				exp_to := exp_args.([2]interface{})[1]
 				if args_v[0] != exp_from {
@@ -356,7 +356,7 @@ func Test_jsonpath_parse_token(t *testing.T) {
 
 		if op == "filter" {
 			if args_v, ok := args.(string); ok == true {
-				fmt.Println(args_v)
+				t.Logf(args_v)
 				if exp_args.(string) != args_v {
 					t.Errorf("len(args) not expected: (got)%v != (exp)%v", len(args_v), len(exp_args.([]string)))
 					return
@@ -374,7 +374,7 @@ func Test_jsonpath_get_key(t *testing.T) {
 		"key": 1,
 	}
 	res, err := get_key(obj, "key")
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 	if err != nil {
 		t.Errorf("failed to get key: %v", err)
 		return
@@ -385,7 +385,7 @@ func Test_jsonpath_get_key(t *testing.T) {
 	}
 
 	res, err = get_key(obj, "hah")
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 	if err == nil {
 		t.Errorf("key error not raised")
 		return
@@ -397,7 +397,7 @@ func Test_jsonpath_get_key(t *testing.T) {
 
 	obj2 := 1
 	res, err = get_key(obj2, "key")
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 	if err == nil {
 
 		t.Errorf("object is not map error not raised")
@@ -406,7 +406,7 @@ func Test_jsonpath_get_key(t *testing.T) {
 	obj3 := map[string]string{"key": "hah"}
 	res, err = get_key(obj3, "key")
 	if res_v, ok := res.(string); ok != true || res_v != "hah" {
-		fmt.Println(err, res)
+		t.Logf("err: %v, res: %v", err, res)
 		t.Errorf("map[string]string support failed")
 	}
 
@@ -419,13 +419,13 @@ func Test_jsonpath_get_key(t *testing.T) {
 		},
 	}
 	res, err = get_key(obj4, "a")
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 }
 
 func Test_jsonpath_get_idx(t *testing.T) {
 	obj := []interface{}{1, 2, 3, 4}
 	res, err := get_idx(obj, 0)
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 	if err != nil {
 		t.Errorf("failed to get_idx(obj,0): %v", err)
 		return
@@ -435,19 +435,19 @@ func Test_jsonpath_get_idx(t *testing.T) {
 	}
 
 	res, err = get_idx(obj, 2)
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 	if v, ok := res.(int); ok != true || v != 3 {
 		t.Errorf("failed to get int 3")
 	}
 	res, err = get_idx(obj, 4)
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 	if err == nil {
 		t.Errorf("index out of range  error not raised")
 		return
 	}
 
 	res, err = get_idx(obj, -1)
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 	if err != nil {
 		t.Errorf("failed to get_idx(obj, -1): %v", err)
 		return
@@ -457,13 +457,13 @@ func Test_jsonpath_get_idx(t *testing.T) {
 	}
 
 	res, err = get_idx(obj, -4)
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 	if v, ok := res.(int); ok != true || v != 1 {
 		t.Errorf("failed to get int 1")
 	}
 
 	res, err = get_idx(obj, -5)
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 	if err == nil {
 		t.Errorf("index out of range  error not raised")
 		return
@@ -478,7 +478,7 @@ func Test_jsonpath_get_idx(t *testing.T) {
 
 	obj2 := []int{1, 2, 3, 4}
 	res, err = get_idx(obj2, 0)
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 	if err != nil {
 		t.Errorf("failed to get_idx(obj2,0): %v", err)
 		return
@@ -492,7 +492,7 @@ func Test_jsonpath_get_range(t *testing.T) {
 	obj := []int{1, 2, 3, 4, 5}
 
 	res, err := get_range(obj, 0, 2)
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 	if err != nil {
 		t.Errorf("failed to get_range: %v", err)
 	}
@@ -502,11 +502,11 @@ func Test_jsonpath_get_range(t *testing.T) {
 
 	obj1 := []interface{}{1, 2, 3, 4, 5}
 	res, err = get_range(obj1, 3, -1)
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 	if err != nil {
 		t.Errorf("failed to get_range: %v", err)
 	}
-	fmt.Println(res.([]interface{}))
+	t.Logf("%v", res.([]interface{}))
 	if res.([]interface{})[0] != 4 || res.([]interface{})[1] != 5 {
 		t.Errorf("failed get_range: %v, expect: [4,5]", res)
 	}
@@ -531,7 +531,7 @@ func Test_jsonpath_get_range(t *testing.T) {
 
 	obj2 := 2
 	res, err = get_range(obj2, 0, 1)
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 	if err == nil {
 		t.Errorf("object is Slice error not raised")
 	}
@@ -542,7 +542,7 @@ func Test_jsonpath_get_scan(t *testing.T) {
 		"key": 1,
 	}
 	res, err := get_scan(obj)
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 	if err != nil {
 		t.Errorf("failed to scan: %v", err)
 		return
@@ -554,7 +554,7 @@ func Test_jsonpath_get_scan(t *testing.T) {
 
 	obj2 := 1
 	res, err = get_scan(obj2)
-	fmt.Println(err, res)
+	t.Logf("err: %v, res: %v", err, res)
 	if err == nil {
 		t.Errorf("object is not scanable error not raised")
 		return
@@ -626,7 +626,7 @@ func Test_jsonpath_get_scan(t *testing.T) {
 func Test_jsonpath_types_eval(t *testing.T) {
 	fset := token.NewFileSet()
 	res, err := types.Eval(fset, nil, 0, "1 < 2")
-	fmt.Println(err, res, res.Type, res.Value, res.IsValue())
+	t.Logf("err: %v, res: %v, res.Type: %v, res.Value: %v, res.IsValue: %v", err, res, res.Type, res.Value, res.IsValue())
 }
 
 var tcase_parse_filter = []map[string]interface{}{
@@ -833,7 +833,7 @@ var tcase_eval_filter = []map[string]interface{}{
 
 func Test_jsonpath_eval_filter(t *testing.T) {
 	for idx, tcase := range tcase_eval_filter[1:] {
-		fmt.Println("------------------------------")
+		t.Logf("------------------------------")
 		obj := tcase["obj"].(map[string]interface{})
 		root := tcase["root"].(map[string]interface{})
 		lp := tcase["lp"].(string)
@@ -1160,7 +1160,7 @@ var tcases_reg_op = []struct {
 
 func TestRegOp(t *testing.T) {
 	for idx, tcase := range tcases_reg_op {
-		fmt.Println("idx: ", idx, "tcase: ", tcase)
+		t.Logf("idx: %v, tcase: %v", idx, tcase)
 		res, err := regFilterCompile(tcase.Line)
 		if tcase.Err == true {
 			if err == nil {


### PR DESCRIPTION
The asterisk operator (`*`), is compiled into the `"scan"` operation, which we are missing a case for.
Fix for: https://github.com/dolthub/dolt/issues/6006